### PR TITLE
Changes to make code thread friendly

### DIFF
--- a/Nsubjettiness/AxesFinder.cc
+++ b/Nsubjettiness/AxesFinder.cc
@@ -41,8 +41,9 @@ std::vector<LightLikeAxis> AxesFinderFromOnePassMinimization::UpdateAxesFast(con
    assert(old_axes.size() == N);
    
    // some storage, declared static to save allocation/re-allocation costs
-   static LightLikeAxis new_axes[N];
-   static fastjet::PseudoJet new_jets[N];
+   // CMS FIX: removed static to make thread safe
+   LightLikeAxis new_axes[N];
+   fastjet::PseudoJet new_jets[N];
    for (int n = 0; n < N; ++n) {
       new_axes[n].reset(0.0,0.0,0.0,0.0);
       new_jets[n].reset_momentum(0.0,0.0,0.0,0.0);

--- a/RecursiveTools/RecursiveSymmetryCutBase.cc
+++ b/RecursiveTools/RecursiveSymmetryCutBase.cc
@@ -36,7 +36,8 @@ LimitedWarning RecursiveSymmetryCutBase::_mu2_gt1_warning;
 //LimitedWarning RecursiveSymmetryCutBase::_nonca_warning;
 LimitedWarning RecursiveSymmetryCutBase::_explicit_ghost_warning;
 
-bool RecursiveSymmetryCutBase::_verbose = false;
+//CMS Fix
+std::atomic<bool> RecursiveSymmetryCutBase::_verbose{ false} ;
 
 //----------------------------------------------------------------------
 PseudoJet RecursiveSymmetryCutBase::result(const PseudoJet & jet) const {

--- a/RecursiveTools/RecursiveSymmetryCutBase.hh
+++ b/RecursiveTools/RecursiveSymmetryCutBase.hh
@@ -27,6 +27,9 @@
 #include "fastjet/tools/Transformer.hh"
 #include "fastjet/WrappedStructure.hh"
 
+//CMS Fix
+#include <atomic>
+
 #include "Recluster.hh"
 
 /** \mainpage RecursiveTools contrib 
@@ -194,7 +197,8 @@ public:
   class StructureType;
 
   /// for testing 
-  static bool _verbose;
+  //CMS fix
+  static std::atomic<bool> _verbose;
 
 protected:
   // the methods below have to be defined by deerived classes

--- a/include/fastjet/contrib/Njettiness.hh
+++ b/include/fastjet/contrib/Njettiness.hh
@@ -478,8 +478,9 @@ std::vector<LightLikeAxis> AxesFinderFromKmeansMinimization::UpdateAxesFast(cons
    assert(old_axes.size() == N);
    
    // some storage, declared static to save allocation/re-allocation costs
-   static LightLikeAxis new_axes[N];
-   static fastjet::PseudoJet new_jets[N];
+   // CMS FIX: removed static to make thread safe
+   LightLikeAxis new_axes[N];
+   fastjet::PseudoJet new_jets[N];
    for (int n = 0; n < N; ++n) {
       new_axes[n].reset(0.0,0.0,0.0,0.0);
 #ifdef FASTJET2


### PR DESCRIPTION
Made function static arrays just be stack arrays and changed static
bools to be std::atomic<bool>. This allows multiple threads to each
safely talk to their own copies of the objects without race conditions.
