### PR TITLE
Removed use of static in DefaultMeasure::UpdateAxesFast

### DIFF
--- a/Nsubjettiness/MeasureDefinition.cc
+++ b/Nsubjettiness/MeasureDefinition.cc
@@ -383,13 +383,8 @@ std::vector<LightLikeAxis> DefaultMeasure::UpdateAxesFast(const std::vector <Lig
                                                           ) const {
    assert(old_axes.size() == N);
    
-   // some storage, declared static to save allocation/re-allocation costs
-   static LightLikeAxis new_axes[N];
-   static fastjet::PseudoJet new_jets[N];
-   for (int n = 0; n < N; ++n) {
-      new_axes[n].reset(0.0,0.0,0.0,0.0);
-      new_jets[n].reset_momentum(0.0,0.0,0.0,0.0);
-   }
+   LightLikeAxis new_axes[N];
+   fastjet::PseudoJet new_jets[N];
 
    double precision = accuracy;  //TODO: actually cascade this in
    


### PR DESCRIPTION
The use of static arrays in DefaultMeasure::UpdateAxesFast caused
thread-safety problems. The stated reason for using the arrays
was to avoid allocation/deallocation but that was also achievable
by having the arrays just be on the stack.
